### PR TITLE
Minor formatting updates to PR 4358

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -131,7 +131,13 @@ At this stage the graph ``G`` consists of 8 nodes and 3 edges, as can be seen by
     >>> G.number_of_edges()
     3
 
-.. note:: With Python 3.6 or later the behavior of Graph/DiGraph is ordered. Since dictionaries became ordered with that version, the order of adjacency reporting: G.adj, G.successors, G.predecessors is now the order of edge adding. However, the order of G.edges is not always the order of edge adding. The order of G.edges is the order of the adjacencies which includes both the order of the nodes and each node's adjacencies. See example below:
+.. note::
+   With Python 3.6 or later the behavior of Graph/DiGraph is ordered.
+   Since dictionaries became ordered with that version, the order of adjacency
+   reporting: G.adj, G.successors, G.predecessors is now the order of edge
+   adding. However, the order of G.edges is not always the order of edge
+   adding. The order of G.edges is the order of the adjacencies which includes
+   both the order of the nodes and each node's adjacencies. See example below:
 
 >>> G = nx.DiGraph()
 >>> G.add_edge(2, 1)   # adds the nodes in order 2, 1

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -139,13 +139,15 @@ At this stage the graph ``G`` consists of 8 nodes and 3 edges, as can be seen by
    adding. The order of G.edges is the order of the adjacencies which includes
    both the order of the nodes and each node's adjacencies. See example below:
 
->>> G = nx.DiGraph()
->>> G.add_edge(2, 1)   # adds the nodes in order 2, 1
->>> G.add_edge(1, 3)
->>> G.add_edge(2, 4)
->>> G.add_edge(1, 2)
->>> assert list(G.successors(2)) == [1, 4]
->>> assert list(G.edges) == [(2, 1), (2, 4), (1, 3), (1, 2)] 
+.. nbplot::
+
+    >>> G = nx.DiGraph()
+    >>> G.add_edge(2, 1)   # adds the nodes in order 2, 1
+    >>> G.add_edge(1, 3)
+    >>> G.add_edge(2, 4)
+    >>> G.add_edge(1, 2)
+    >>> assert list(G.successors(2)) == [1, 4]
+    >>> assert list(G.edges) == [(2, 1), (2, 4), (1, 3), (1, 2)]
 
 Examining elements of a graph
 -----------------------------


### PR DESCRIPTION
Just a couple formatting-related touchups for PR 4358:
  * 80ish character line limit (usually the linter fixes this, but it's not running on the .rst in this case)
  * Wraps the added example in an `nbplot` directive, for consistency with the rest of the tutorial (should also execute the code during building).

Normally I'd just push these type of changes to your branch, but since #4358 originates from your `master` branch that's disallowed :)

I have a couple wording suggestions as well, but they're just suggestions, so I'll way for this to get in then use GH's suggestion feature to follow up!